### PR TITLE
Fix: Propagate bundled feature in the crater

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ keywords = ["database"]
 [features]
 default = ["linkage"]
 linkage = ["sqlite3-src"]
+bundled = ["sqlite3-src/bundled"]
 
 [dependencies]
 libc = "0.2"


### PR DESCRIPTION
In a project that I am involved, I need to include sqllite3 inside the binary 
and we noted that it is missing the feature that propagates 
the feature to `sqlite3-src`.

However, it is possible to enable the feature with the following 
syntax inside the `Cargo.toml`. I think it would be nice to support this 
feature directly inside the following package.


```
[dependencies.sqlite3-src]
--
60 | version = "0.4"
61 | features = ["bundled"]
```

Thanks to keep maintaining this crate, and keeping it minimal